### PR TITLE
Cambio version de ckan a 2.5.4

### DIFF
--- a/base_portal/roles/portal/tasks/install_ckan.yml
+++ b/base_portal/roles/portal/tasks/install_ckan.yml
@@ -8,7 +8,7 @@
 
 - name: Download ckan deb from Azure
   get_url:
-    url: https://modernizacion.blob.core.windows.net/debs/ckan_2.5.3-trusty_amd64.deb
+    url: http://packaging.ckan.org/python-ckan_2.5-trusty_amd64.deb
     dest: /tmp/python-ckan_2.5-trusty_amd64.deb
 
 - name: Setup dirs


### PR DESCRIPTION
Mergear ckan_version a master, habiendo mergeado previamente datajson_improvements a master en el repositorio de datajsonAR.