### PR TITLE
Eliminar `processes=1` para fozar `wsgi.multiprocess=false`

### DIFF
--- a/base_portal/roles/portal/templates/apache/ckan_default.conf.j2
+++ b/base_portal/roles/portal/templates/apache/ckan_default.conf.j2
@@ -8,7 +8,7 @@ WSGISocketPrefix /var/run/wsgi
     WSGIPassAuthorization On
 
     # Deploy as a daemon (avoids conflicts between CKAN instances)
-    WSGIDaemonProcess ckan_default display-name=ckan_default processes=1 threads=20
+    WSGIDaemonProcess ckan_default display-name=ckan_default threads=20
 
     WSGIProcessGroup ckan_default
 


### PR DESCRIPTION
Hay una diferencia entre no especificar el parámetro `processes` y asignarle el valor 1 (ver links debajo). No estoy diciendo que es estrictamente necesario, pero revisando la documentación de mod_wsgi noté que recomendaban hacerlo de esta manera.

resolves #11 

http://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIDaemonProcess.html: Note that if this option is defined as processes=1, then the WSGI environment attribute called wsgi.multiprocess will be set to be True whereas not providing the option at all will result in the attribute being set to be False. This distinction is to allow for where some form of load balancing is used across process groups in the same Apache instance, or separate Apache instances. If you need to ensure that wsgi.multiprocess is False so that interactive debuggers will work, simply do not specify the processes option and allow the default single daemon process to be created in the process group.