### PR TITLE
44 custom ports

### DIFF
--- a/deploy/install.py
+++ b/deploy/install.py
@@ -13,6 +13,8 @@ parser.add_argument('--database_user', required=True)
 parser.add_argument('--database_password', required=True)
 parser.add_argument('--datastore_user', required=True)
 parser.add_argument('--datastore_password', required=True)
+parser.add_argument('--nginx_port', default="80")
+parser.add_argument('--datastore_port', default="8800")
 parser.add_argument('--repo', choices=['portal-andino', 'portal_datos.gob.ar'], default='portal-andino')
 parser.add_argument('--branch', default='master')
 
@@ -53,6 +55,8 @@ def configure_env_file(base_path):
     with open(env_file_path, "w") as env_f:
         env_f.write("POSTGRES_USER=%s\n" % args.database_user)
         env_f.write("POSTGRES_PASSWORD=%s\n" % args.database_password)
+        env_f.write("NGINX_HOST_PORT=%s\n" % args.nginx_port)
+        env_f.write("DATASTORE_HOST_PORT=%s\n" % args.datastore_port)
 
 
 def init_application(compose_path):

--- a/deploy/update.py
+++ b/deploy/update.py
@@ -57,6 +57,16 @@ def get_compose_file(base_path):
     ])
     return compose_file_path
 
+def fix_env_file(base_path):
+    env_file = ".env"
+    env_file_path = path.join(base_path, env_file)
+    nginx_var = "NGINX_HOST_PORT"
+    datastore_var = "DATASTORE_HOST_PORT"
+    with open(env_file_path, "a") as env_f:
+        if nginx_var not in env_f:
+            env_f.write("%s=%s\n" % (nginx_var, "80"))
+        if datastore_var not in env_f:
+            env_f.write("%s=%s\n" % (datastore_var, "8800"))
 
 def backup_database(base_path, compose_path):
     db_container = subprocess.check_output(["docker-compose", "-f", compose_path, "ps", "-q", "db"])
@@ -176,6 +186,7 @@ print("[ INFO ] Comprobando instalación previa...")
 check_previous_installation(directory)
 print("[ INFO ] Descargando archivos necesarios...")
 compose_file_path = get_compose_file(directory)
+fix_env_file(directory)
 print("[ INFO ] Guardando base de datos...")
 backup_database(directory, compose_file_path)
 print("[ INFO ] Actualizando la aplicación")

--- a/deploy/update.py
+++ b/deploy/update.py
@@ -62,10 +62,11 @@ def fix_env_file(base_path):
     env_file_path = path.join(base_path, env_file)
     nginx_var = "NGINX_HOST_PORT"
     datastore_var = "DATASTORE_HOST_PORT"
-    with open(env_file_path, "a") as env_f:
-        if nginx_var not in env_f:
+    with open(env_file_path, "r+a") as env_f:
+        content = env_f.read()
+        if nginx_var not in content:
             env_f.write("%s=%s\n" % (nginx_var, "80"))
-        if datastore_var not in env_f:
+        if datastore_var not in content:
             env_f.write("%s=%s\n" % (datastore_var, "8800"))
 
 def backup_database(base_path, compose_path):

--- a/docs/deploy/install.md
+++ b/docs/deploy/install.md
@@ -4,9 +4,9 @@ La instalación de portales puede ser llevada a cabo mediantes el script `deploy
 Para ello, puede descargarse y correrlo en línea de comando.
 
     wget https://raw.github.com/datosgobar/portal-base/master/deploy/install.py
-    
-    python ./install.py 
-    
+
+    python ./install.py
+
 Es script requerirá ciertos parámetros para completar la instalación:
 
     --error_email <email donde se enviarán los errores de la aplicación>
@@ -15,11 +15,13 @@ Es script requerirá ciertos parámetros para completar la instalación:
     --database_password <contraseña de la base de datos a crear>
     --datastore_user <usuario del "datastore" de ckan a crear>
     --datastore_password <contraseña del "datastore" de ckan a crear>
-  
+
 Además, acepta los siguientes parámetros, con sus correspondientes valores por defecto:
 
     --repo < portal_datos.gob.ar o portal-andino> default: portal-andino
     --branch < tag o branch a instalar de la aplicación > default: master
+    --nginx_port < puerto > default: 80
+    --datastore_port < puerto > default: 8800
 
 El script tiene el comportamiento predeterminado de instalar la *última versión* de **portal-andino**.
 
@@ -30,14 +32,14 @@ Por ejemplo, si deseo instalar la aplicación en `/etc/mi_portal`:
     cd /etc/mi_portal
     sudo wget https://raw.github.com/datosgobar/portal-base/master/deploy/install.py
     sudo python ./install.py
-    
+
 O puedo instalarla en alguna carpeta de un usuario:
 
     mkdir ~/mi_portal/
     cd ~/mi_portal/
     wget https://raw.github.com/datosgobar/portal-base/master/deploy/install.py
     python ./install.py
-    
+
 
 ## Portal andino
 


### PR DESCRIPTION
Los puertos de nginx y el datastore pueden customizarse mediante las variables NGINX_HOST_PORT y DATASTORE_HOSR_PORT en el `.env`.

El archivo `install.py` ahora agrega esas variables con los defaults en 80 y 8800.
El archivo `update.py` comprueba que estén, si no están, los agrega. Esto es para compatibilidad con versiones anteriores que no incluian estas variables al momento de la instalacion.

## Testing

1) Instalación

Descargar el install.py desde el branch para probar la funcionalidad

    wget https://raw.github.com/datosgobar/portal-base/44-custom-ports/deploy/update.py

Correr el script para que instale la version del branch 44-custom-ports

    python ./install.py --error_email "admin@example.com" --site_host="localhost"     --database_user="ckan" --database_password="ckan"    --datastore_user="store" --datastore_password="store" --branch 44-custom-ports

La aplicacion deberia estar corriendo en el puerto 80 y el archivo `.env` deberia tener las variables NGINX_HOST_PORT y DATASTORE_HOSR_PORT 
    cat .env

Si se cambia el valor de la variable NGINX_HOST_PORT a (por ejemplo) 801 y se *recrean* los contenedores, deberia dejar la aplicacion corriendo en 801

Para recrear los contenedores:

    docker-compose -f latest.yml up -d

2) Actualizacion

Si una instalacion previa no incluye las variables en el `.env`, el archivo `update.py` las agregara.

Para probar esto esto basta con descargar el nuevo archivo desde el branch

    wget https://raw.github.com/datosgobar/portal-base/44-custom-ports/deploy/update.py

Y correr el script para que instale la version del branch 44-custom-ports

    python update.py --branch 44-custom-ports

**Antes de mergear este pull-request, debe mergearse el de andino**. [Ver aquí](https://github.com/datosgobar/portal-andino/pull/46)

Luego que se mergee este pull-request, **no será necesario aclarar el branch en los comandos arriba usados**