### PR TITLE
Fix emails

### DIFF
--- a/base_portal/roles/portal/templates/ckan/production.ini.j2
+++ b/base_portal/roles/portal/templates/ckan/production.ini.j2
@@ -180,9 +180,9 @@ email_to =
 error_email_from =
 smtp.server = {{ DEFAULT_EMAIL_HOST }}
 #smtp.starttls = False
-#smtp.user = your_username@gmail.com
-#smtp.password = your_password
-#smtp.mail_from =
+smtp.user = portal
+smtp.password = portal
+smtp.mail_from = administrador
 
 ## Redis
 ckan.redis.url = redis://{{ DEFAULT_REDIS_HOST }}:{{ DEFAULT_REDIS_PORT }}/{{ DEFAULT_REDIS_DB }}

--- a/deploy/install.py
+++ b/deploy/install.py
@@ -57,6 +57,7 @@ def configure_env_file(base_path):
         env_f.write("POSTGRES_PASSWORD=%s\n" % args.database_password)
         env_f.write("NGINX_HOST_PORT=%s\n" % args.nginx_port)
         env_f.write("DATASTORE_HOST_PORT=%s\n" % args.datastore_port)
+        env_f.write("maildomain=%s\n" % args.site_host)
 
 
 def init_application(compose_path):

--- a/deploy/update.py
+++ b/deploy/update.py
@@ -31,6 +31,12 @@ EXPECTED_CONTAINERS = REPOS[args.repo]['containers']
 UPGRADE_DB_COMMAND = "/etc/ckan_init.d/upgrade_db.sh"
 REBUILD_SEARCH_COMMAND = "/etc/ckan_init.d/run_rebuild_search.sh"
 
+def ask(question):
+    try:
+        _ask = raw_input
+    except NameError:
+        _ask = input
+    return _ask("%s\n" % question)
 
 def check_docker():
     subprocess.check_call([
@@ -62,12 +68,21 @@ def fix_env_file(base_path):
     env_file_path = path.join(base_path, env_file)
     nginx_var = "NGINX_HOST_PORT"
     datastore_var = "DATASTORE_HOST_PORT"
+    maildomain_var = "maildomain"
     with open(env_file_path, "r+a") as env_f:
         content = env_f.read()
         if nginx_var not in content:
             env_f.write("%s=%s\n" % (nginx_var, "80"))
         if datastore_var not in content:
             env_f.write("%s=%s\n" % (datastore_var, "8800"))
+        if maildomain_var not in content:
+            maildomain = ask("Por favor, ingrese su dominio para envío de emails (e.g.: myportal.com.ar): ")
+            real_maildomain = maildomain.strip()
+            if not real_maildomain:
+                print("Ningun valor fue ingresado, usando valor por defecto: localhost")
+                real_maildomain = "localhost"
+            env_f.write("%s=%s\n" % (maildomain_var, real_maildomain))
+
 
 def backup_database(base_path, compose_path):
     db_container = subprocess.check_output(["docker-compose", "-f", compose_path, "ps", "-q", "db"])


### PR DESCRIPTION
Arregla la configuracion de mail.
Configura por defecto el usuario `portal` y la contraseña `portal` para un servidor interno `portfix`.

Estos cambios permitiran que las nuevas versiones del portal (andino como datos) puedan enviar mails (actualmente no funcionan).
Luego de estos cambios, hay que sacar un nuevo release y actualizar las versiones base de los portales.

El script de instalacion seteará por defecto el `mailhost` requerido por **postfix**, y el de update se lo preguntará al usuario.

cc @iheredia 