### PR TITLE
Arreglo script de inicializacion de desarrollo

### DIFF
--- a/base_portal/roles/portal/templates/scripts/config/init.sh
+++ b/base_portal/roles/portal/templates/scripts/config/init.sh
@@ -59,12 +59,11 @@ done
 >&2 echo "Postgres is up - executing command"
 
 
-datapusher_host=$(/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
 beaker_session_secret=$(openssl rand -base64 25)
 psql -c "CREATE ROLE $datastore_user WITH PASSWORD '$datastore_password';"
 psql -c "CREATE DATABASE $DATASTORE_DB OWNER $database_user;"
 
-"$current_dir/change_datapusher_url.sh" "http://$datapusher_host:8800"
+"$current_dir/change_datapusher_url.sh" "http://0.0.0.0:8800"
 "$current_dir/update_conf.sh" "error_email_from=$error_email"
 "$current_dir/change_site_url.sh" "http://$site_host"
 "$current_dir/update_conf.sh" "sqlalchemy.url=postgresql://$database_user:$database_password@$PGHOST:$PGPORT/$PGDATABASE"

--- a/base_portal/roles/portal/templates/scripts/config/init_dev.sh
+++ b/base_portal/roles/portal/templates/scripts/config/init_dev.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 current_dir="$(dirname "$0")"
 
-"$current_dir/init.sh" -e admin@example.com -h localhost -p ckan -P ckan -d ckan_datastore -D ckan_datastore
+"$current_dir/init.sh" -e admin@example.com -h localhost:8080 -p ckan -P ckan -d ckan_datastore -D ckan_datastore


### PR DESCRIPTION
En desarrollo, "localhost" es resuelto a IPs distintas segun en que container se está.
La solucion *para desarrolo* es abrir el puerto 8080 en localhost y ademas setear el site_url a "locahost:8080". Este branch inplementa esta ultima parte correctamente.

refs:datosgobar/portal-andino#49