### PR TITLE
Configuracion de cache

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -2,7 +2,9 @@ FROM openresty/openresty:1.13.6.2-alpine
 MAINTAINER Leandro Gomez<lgomez@devartis.com>
 
 ENV NGINX_AVAILABLE_SITES=/etc/nginx/site-available \
-    NGINX_DEFAULT_CONFIG_FILE=nginx.conf
+    NGINX_DEFAULT_CONFIG_FILE=nginx.conf \
+    NGINX_DEFAULT_CACHE_MAX_SIZE=1g \
+    NGINX_DEFAULT_CACHE_INACTIVE=240m
 
 RUN mkdir -p $NGINX_AVAILABLE_SITES
 COPY configs/ $NGINX_AVAILABLE_SITES

--- a/nginx/command.sh
+++ b/nginx/command.sh
@@ -15,18 +15,16 @@ max_size="$NGINX_DEFAULT_CACHE_MAX_SIZE";
 if [[ -n "$NGINX_CACHE_MAX_SIZE" ]]; then
     max_size="$NGINX_CACHE_MAX_SIZE";
 fi
-sed -i "s/max_size=[^\s]*/max_size=$max_size /" /etc/nginx/conf.d/default.conf
+sed -i "s/max_size=[[:alnum:]]*[[:space:]]/max_size=$max_size /" /etc/nginx/conf.d/default.conf
 
 
+# Configure inactive cache option
 #inactive="$NGINX_DEFAULT_CACHE_INACTIVE";
 #if [[ -n "$NGINX_CACHE_INACTIVE" ]]; then
 #    inactive="$NGINX_CACHE_INACTIVE";
 #fi
-#
-#
-#sed -i 's/original/new/g' /etc/nginx/conf.d/default.conf
+#sed -i "s/inactive=[^\s]*/inactive=$inactive /" /etc/nginx/conf.d/default.conf
 
-sed -i "s/proxy_cache_path.*/&;/" /etc/nginx/conf.d/default.conf
 
 echo "Stating nginx (with openresty)...";
 /usr/local/openresty/bin/openresty -g "daemon off;";

--- a/nginx/command.sh
+++ b/nginx/command.sh
@@ -15,15 +15,15 @@ max_size="$NGINX_DEFAULT_CACHE_MAX_SIZE";
 if [[ -n "$NGINX_CACHE_MAX_SIZE" ]]; then
     max_size="$NGINX_CACHE_MAX_SIZE";
 fi
-sed -i "s/max_size=[[:alnum:]]*[[:space:]]/max_size=$max_size /" /etc/nginx/conf.d/default.conf
+sed -i "s/max_size=[[:alnum:]]*/max_size=$max_size/" /etc/nginx/conf.d/default.conf
 
 
 # Configure inactive cache option
-#inactive="$NGINX_DEFAULT_CACHE_INACTIVE";
-#if [[ -n "$NGINX_CACHE_INACTIVE" ]]; then
-#    inactive="$NGINX_CACHE_INACTIVE";
-#fi
-#sed -i "s/inactive=[^\s]*/inactive=$inactive /" /etc/nginx/conf.d/default.conf
+inactive="$NGINX_DEFAULT_CACHE_INACTIVE";
+if [[ -n "$NGINX_CACHE_INACTIVE" ]]; then
+    inactive="$NGINX_CACHE_INACTIVE";
+fi
+sed -i "s/inactive=[[:alnum:]]*/inactive=$inactive/" /etc/nginx/conf.d/default.conf
 
 
 echo "Stating nginx (with openresty)...";

--- a/nginx/command.sh
+++ b/nginx/command.sh
@@ -10,5 +10,23 @@ else
     ln -s "$NGINX_AVAILABLE_SITES/$NGINX_DEFAULT_CONFIG_FILE" /etc/nginx/conf.d/default.conf;
 fi
 
+# Configure max_size cache option
+max_size="$NGINX_DEFAULT_CACHE_MAX_SIZE";
+if [[ -n "$NGINX_CACHE_MAX_SIZE" ]]; then
+    max_size="$NGINX_CACHE_MAX_SIZE";
+fi
+sed -i "s/max_size=[^\s]*/max_size=$max_size /" /etc/nginx/conf.d/default.conf
+
+
+#inactive="$NGINX_DEFAULT_CACHE_INACTIVE";
+#if [[ -n "$NGINX_CACHE_INACTIVE" ]]; then
+#    inactive="$NGINX_CACHE_INACTIVE";
+#fi
+#
+#
+#sed -i 's/original/new/g' /etc/nginx/conf.d/default.conf
+
+sed -i "s/proxy_cache_path.*/&;/" /etc/nginx/conf.d/default.conf
+
 echo "Stating nginx (with openresty)...";
 /usr/local/openresty/bin/openresty -g "daemon off;";

--- a/nginx/configs/nginx.conf
+++ b/nginx/configs/nginx.conf
@@ -1,4 +1,8 @@
-proxy_cache_path /tmp/nginx_cache levels=1:2 keys_zone=cache:30m max_size=250m;
+proxy_cache_path /tmp/nginx_cache/ levels=1:2 keys_zone=cache:30m max_size=1g inactive=240m;
+# keys: 8000 * 30 = 240000 keys
+# 1 GB of data
+# 240 minutes (4 hours)
+
 proxy_temp_path /tmp/nginx_proxy 1 2;
 
 server {

--- a/nginx/configs/nginx_extended.conf
+++ b/nginx/configs/nginx_extended.conf
@@ -1,4 +1,8 @@
-proxy_cache_path /tmp/nginx_cache/ levels=1:2 keys_zone=cache:30m max_size=250m;
+proxy_cache_path /tmp/nginx_cache/ levels=1:2 keys_zone=cache:30m max_size=1g inactive=240m;
+# keys: 8000 * 30 = 240000 keys
+# 1 GB of data
+# 240 minutes (4 hours)
+
 proxy_temp_path /tmp/nginx_proxy 1 2;
 
 server_tokens off;


### PR DESCRIPTION
Agrego la capacidad de configurar dos opciones de la cache de nginx mediante variables de entorno:

- `max_size`: `NGINX_CACHE_MAX_SIZE`
- `inactive`: `NGINX_CACHE_INACTIVE`

Ambos deben respectar el formato descripto en http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_path.

Para probarlo, necesitamos:

1. Crear la nueva imagen: `docker-compose build nginx`
1. Levantar un nuevo contenedor: `docker-compose run --rm -e NGINX_CACHE_INACTIVE=120m -e NGINX_CACHE_MAX_SIZE=2g nginx sh`
1. Correr `sh command.sh`.
1. Ignorar el error `nginx: [emerg] host not found in upstream "portal" in /etc/nginx/conf.d/default.conf:11`
1. verificar que el archivo `/etc/nginc/conf.d/default.conf` contiene las opciones de cache con los valores que pasamos.