### PR TITLE
Actualización de la configuración de supervisor

### DIFF
--- a/base_portal/roles/portal/templates/ckan/supervisor-ckan-worker.conf.j2
+++ b/base_portal/roles/portal/templates/ckan/supervisor-ckan-worker.conf.j2
@@ -24,3 +24,8 @@ stderr_logfile=/var/log/ckan-andino-datajson-queue-worker.log
 autostart=true
 autorestart=true
 startsecs=10
+
+[program:cron]
+command = cron -f -L 15
+autostart=true
+autorestart=true


### PR DESCRIPTION
Se modificó la configuración de supervisor para poder utilizar `crontab` correctamente, ya que los jobs no se ejecutaban.