### PR TITLE
Especificación de la URI de la API de series en el archivo de configuración

### DIFF
--- a/base_portal/roles/portal/templates/ckan/production.ini.j2
+++ b/base_portal/roles/portal/templates/ckan/production.ini.j2
@@ -31,6 +31,7 @@ ckan.site.title =
 ckan.site.description =
 ckan.owner =
 ckan.owner.email =
+seriesapi.site_uri = https://apis.datos.gob.ar/series/api
 #andino.cache_clean_hook =
 #andino.cache_clean_hook_method = PURGE
 

--- a/base_portal/roles/portal/templates/ckan/production.ini.j2
+++ b/base_portal/roles/portal/templates/ckan/production.ini.j2
@@ -31,7 +31,7 @@ ckan.site.title =
 ckan.site.description =
 ckan.owner =
 ckan.owner.email =
-seriesapi.site_uri = https://apis.datos.gob.ar/series/api
+seriestiempoarexplorer.default_series_api_uri = https://apis.datos.gob.ar/series/api
 #andino.cache_clean_hook =
 #andino.cache_clean_hook_method = PURGE
 


### PR DESCRIPTION
Se creó un campo nuevo en el archivo de configuración que sirve para especificar la URI de la API. Por default, se utiliza el valor anteriormente utilizado (`https://apis.datos.gob.ar/series/api`).
Closes #65.