### PR TITLE
Volumen en el contenedor de Nginx

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -12,4 +12,6 @@ RUN mkdir -p $NGINX_AVAILABLE_SITES
 COPY configs/ $NGINX_AVAILABLE_SITES
 COPY command.sh .
 
+VOLUME $NGINX_SSL_CONFIG_DATA
+
 CMD ["sh", "command.sh"]


### PR DESCRIPTION
Se especificó un volumen en el Dockerfile de Nginx, el cual permitirá persistir los certificados.

Requiere el mergeado de #70.

Closes #69.