### PR TITLE
Copiado de archivos SSL al contenedor de Nginx

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -13,5 +13,6 @@ COPY configs/ $NGINX_AVAILABLE_SITES
 COPY command.sh .
 
 VOLUME $NGINX_SSL_CONFIG_DATA
+RUN apk add --no-cache openssl
 
 CMD ["sh", "command.sh"]

--- a/nginx/command.sh
+++ b/nginx/command.sh
@@ -3,24 +3,17 @@ set -e;
 
 rm -f /etc/nginx/conf.d/default.conf;
 
-# Por el momento, no se puede utilizar este bloque ya que se requieren los archivos de configuración; usamos el original
-#if [ -d "$NGINX_AVAILABLE_SITES" ] ; then
-#    ln -s "$NGINX_SSL_CONFIG_FILE" /etc/nginx/conf.d/default.conf;
-#else
-#    if [[ -n "$NGINX_CONFIG_FILE" ]]; then
-#        echo "Using '$NGINX_CONFIG_FILE' configuration"
-#        ln -s "$NGINX_AVAILABLE_SITES/$NGINX_CONFIG_FILE" /etc/nginx/conf.d/default.conf;
-#    else
-#        echo "Using '$NGINX_DEFAULT_CONFIG_FILE' default configuration"
-#        ln -s "$NGINX_AVAILABLE_SITES/$NGINX_DEFAULT_CONFIG_FILE" /etc/nginx/conf.d/default.conf;
-#    fi
-#fi
-if [[ -n "$NGINX_CONFIG_FILE" ]]; then
-    echo "Using '$NGINX_CONFIG_FILE' configuration"
-    ln -s "$NGINX_AVAILABLE_SITES/$NGINX_CONFIG_FILE" /etc/nginx/conf.d/default.conf;
+if [ -d "$NGINX_AVAILABLE_SITES" ] ; then
+    ln -s "$NGINX_AVAILABLE_SITES"/"$NGINX_SSL_CONFIG_FILE" /etc/nginx/conf.d/default.conf;
+    openssl dhparam 2048 -out $NGINX_SSL_CONFIG_DATA/andino_dhparam.pem
 else
-    echo "Using '$NGINX_DEFAULT_CONFIG_FILE' default configuration"
-    ln -s "$NGINX_AVAILABLE_SITES/$NGINX_DEFAULT_CONFIG_FILE" /etc/nginx/conf.d/default.conf;
+    if [[ -n "$NGINX_CONFIG_FILE" ]]; then
+        echo "Using '$NGINX_CONFIG_FILE' configuration"
+        ln -s "$NGINX_AVAILABLE_SITES/$NGINX_CONFIG_FILE" /etc/nginx/conf.d/default.conf;
+    else
+        echo "Using '$NGINX_DEFAULT_CONFIG_FILE' default configuration"
+        ln -s "$NGINX_AVAILABLE_SITES/$NGINX_DEFAULT_CONFIG_FILE" /etc/nginx/conf.d/default.conf;
+    fi
 fi
 
 # Configure max_size cache option


### PR DESCRIPTION
Se realizó una modificación en los archivos de Nginx para poder utilizar directamente el archivo de configuración de SSL. Esto _no será permanente_, ya que se deberá darle al usuario la posibilidad de elegir el archivo en vez de utilizar siempre el mismo.

Ver datosgobar/portal-andino#176.