### PR TITLE
Cambio header de la configuración SSL de Nginx

### DIFF
--- a/nginx/configs/nginx_ssl.conf
+++ b/nginx/configs/nginx_ssl.conf
@@ -39,7 +39,7 @@ server {
         proxy_pass http://portal:8080/;
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-Protocol https;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_redirect off;
         proxy_cache cache;
         proxy_cache_bypass $cookie_auth_tkt;


### PR DESCRIPTION
Cambio `X-Forwarded-Protocol` por `X-Forwarded-Proto`.

Ciertos plugins esperan el header `X-Forwarded-Proto` pero, al tenerlo con un nombre distinto, ocurre comportamiento indeseado.

Closes #87 .