### PR TITLE
Creo scripts y un who.ini para el uso de ckanext-security

### DIFF
--- a/base_portal/group_vars/all.yml
+++ b/base_portal/group_vars/all.yml
@@ -9,6 +9,7 @@ CKAN_HOME: /usr/lib/ckan/default
 DATAPUSHER_HOME: /usr/lib/ckan/datapusher
 CKAN_CONFIG: /etc/ckan/default
 CKAN_HARVEST_GCF: /var/log/ckan/std
+SECURITY_DIR: "{{ CKAN_INIT }}/security/"
 UPDATE_DIR: "{{ CKAN_INIT }}/updates/"
 
 DEFAULT_CKAN_DATA: /var/lib/ckan

--- a/base_portal/roles/portal/tasks/configure.yml
+++ b/base_portal/roles/portal/tasks/configure.yml
@@ -22,6 +22,11 @@
     src: ckan/production.ini.j2
     dest: "{{ CKAN_CONFIG }}/{{ CKAN_CONFIG_FILE }}"
 
+- name: Add security configuration file
+  template:
+    src: scripts/security/who_security.ini.j2
+    dest: "{{ CKAN_CONFIG }}/who_security.ini"
+
 - name: Add licenses JSON file
   template:
     src: ckan/licenses.json.j2
@@ -86,6 +91,14 @@
     - {src: start_rebuild_cron.sh.j2, dest: start_rebuild_cron.sh}
     - {src: sync_rebuild_tasks.sh.j2, dest: sync_rebuild_tasks.sh}
     - {src: update_data_json_and_catalog_xlsx.sh.j2, dest: update_data_json_and_catalog_xlsx.sh}
+
+- name: Add security scripts
+  template:
+    src: "scripts/security/{{ item.src }}"
+    dest: "{{ SECURITY_DIR }}/{{ item.dest }}"
+  with_items:
+    - {src: enable_ckanext_security.sh.j2, dest: enable_ckanext_security.sh}
+    - {src: disable_ckanext_security.sh.j2, dest: disable_ckanext_security.sh}
 
 - name: Add update scripts
   template:

--- a/base_portal/roles/portal/tasks/install_ckan.yml
+++ b/base_portal/roles/portal/tasks/install_ckan.yml
@@ -14,6 +14,7 @@
     - "{{ CKAN_CONFIG }}"
     - "{{ DEFAULT_CKAN_DATA }}"
     - "{{ CKAN_INIT }}"
+    - "{{ SECURITY_DIR }}"
     - "{{ UPDATE_DIR }}"
 
 - name: Setup ckan_init.d subdirectories

--- a/base_portal/roles/portal/templates/scripts/security/disable_ckanext_security.sh.j2
+++ b/base_portal/roles/portal/templates/scripts/security/disable_ckanext_security.sh.j2
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#config_file="{{ CKAN_CONFIG }}/{{ CKAN_CONFIG_FILE }}";
+config_file="/etc/ckan/default/production.ini";
+
+if ! grep '## ckanext-security' $config_file ; then
+    exit 0
+fi
+
+cd /usr/lib/ckan/default/src/ckan
+git reset ckan/config/middleware/pylons_app.py
+git checkout ckan/config/middleware/pylons_app.py
+
+
+## Modificaciones del production.ini
+
+# Buscamos el site_url
+site_url=$(grep -r ckan.site_url $config_file | sed 's/https\?:\/\///' | awk '{print $(NF)}')
+
+# Borramos configuraciones del plugin
+sed -i '/^## ckanext-security/,/^ckanext.security.redis.port/d' /etc/ckan/default/production.ini
+
+# Removemos el plugin de la lista
+sed -i '/ckan.plugins[[:space:]]*=/s/security googleanalytics/googleanalytics/' $config_file
+
+# Especificamos el uso del who.ini
+sed -i '/who.config_file/s/who_security.ini/who.ini/' $config_file

--- a/base_portal/roles/portal/templates/scripts/security/disable_ckanext_security.sh.j2
+++ b/base_portal/roles/portal/templates/scripts/security/disable_ckanext_security.sh.j2
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-#config_file="{{ CKAN_CONFIG }}/{{ CKAN_CONFIG_FILE }}";
 config_file="/etc/ckan/default/production.ini";
 
 if ! grep '## ckanext-security' $config_file ; then

--- a/base_portal/roles/portal/templates/scripts/security/enable_ckanext_security.sh.j2
+++ b/base_portal/roles/portal/templates/scripts/security/enable_ckanext_security.sh.j2
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-#config_file="{{ CKAN_CONFIG }}/{{ CKAN_CONFIG_FILE }}";
 config_file="/etc/ckan/default/production.ini";
 
 if grep '## ckanext-security' $config_file ; then

--- a/base_portal/roles/portal/templates/scripts/security/enable_ckanext_security.sh.j2
+++ b/base_portal/roles/portal/templates/scripts/security/enable_ckanext_security.sh.j2
@@ -9,8 +9,8 @@ fi
 . /usr/lib/ckan/default/bin/activate
 pip install -e 'git+https://github.com/data-govt-nz/ckanext-security.git#egg=ckanext-security==1.0.1'
 cd /usr/lib/ckan/default/src/ckan
-git remote add -f data-govt-nz https://github.com/data-govt-nz/ckan.git
-git cherry-pick 74f78865b8825c91d1dfe6b189228f4b975610a3
+git remote add -f data-govt-nz https://github.com/data-govt-nz/ckan.git 2> /dev/null
+git cherry-pick 74f78865b8825c91d1dfe6b189228f4b975610a3 2> /dev/null
 cd -
 
 

--- a/base_portal/roles/portal/templates/scripts/security/enable_ckanext_security.sh.j2
+++ b/base_portal/roles/portal/templates/scripts/security/enable_ckanext_security.sh.j2
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#config_file="{{ CKAN_CONFIG }}/{{ CKAN_CONFIG_FILE }}";
+config_file="/etc/ckan/default/production.ini";
+
+if grep '## ckanext-security' $config_file ; then
+    exit 0
+fi
+
+. /usr/lib/ckan/default/bin/activate
+pip install -e 'git+https://github.com/data-govt-nz/ckanext-security.git#egg=ckanext-security==1.0.1'
+cd /usr/lib/ckan/default/src/ckan
+git remote add -f data-govt-nz https://github.com/data-govt-nz/ckan.git
+git cherry-pick 74f78865b8825c91d1dfe6b189228f4b975610a3
+cd -
+
+
+## Modificaciones del production.ini
+
+# Buscamos el site_url
+site_url=$(grep -r ckan.site_url $config_file | sed 's/https\?:\/\///' | awk '{print $(NF)}')
+
+# Agregamos el texto "## ckanext-security" debajo del campo "beaker.session.secret"
+sed -i '/beaker.session.secret/{N;a ## ckanext-security
+}' $config_file
+
+# Agregamos configuraciones para el plugin
+sed -i "/## ckanext-security/{
+a beaker.session.cookie_domain = $site_url
+a beaker.session.cookie_expires = true
+a beaker.session.data_serializer = json
+a beaker.session.httponly = true
+a beaker.session.save_accessed_time = true
+a beaker.session.secure = true
+a beaker.session.timeout = 3600
+a beaker.session.type = redis
+a beaker.session.url = redis:6379
+a ckanext.security.domain = $site_url
+a ckanext.security.lock_timeout = 900
+a ckanext.security.login_max_count = 10
+a ckanext.security.redis.db = 1
+a ckanext.security.redis.host = redis
+a ckanext.security.redis.port = 6379
+a
+}" $config_file
+
+# Añadimos el plugin a la lista
+sed -i '/ckan.plugins[[:space:]]*=/s/googleanalytics/security googleanalytics/' $config_file
+
+# Cambiamos el valor de "beaker.session.key"
+sed -i -r 's/(beaker.session.key[[:space:]]*=).*/\1 ckan_session/' $config_file
+
+# Especificamos el uso de un who.ini diseñado para el plugin
+sed -i '/who.config_file/s/who.ini/who_security.ini/' $config_file

--- a/base_portal/roles/portal/templates/scripts/security/who_security.ini.j2
+++ b/base_portal/roles/portal/templates/scripts/security/who_security.ini.j2
@@ -1,0 +1,42 @@
+[plugin:use_beaker]
+use = repoze.who.plugins.use_beaker:make_plugin
+key_name = ckan_session
+delete_on_logout = True
+
+[plugin:auth_tkt]
+use = ckan.lib.auth_tkt:make_plugin
+# If no secret key is defined here, beaker.session.secret will be used
+#secret = somesecret
+
+[plugin:friendlyform]
+use = repoze.who.plugins.friendlyform:FriendlyFormPlugin
+login_form_url= /user/login
+login_handler_path = /login_generic
+logout_handler_path = /user/logout
+rememberer_name = use_beaker
+post_login_url = /user/logged_in
+post_logout_url = /user/logged_out
+charset = utf-8
+
+#[plugin:basicauth]
+#use = repoze.who.plugins.basicauth:make_plugin
+#realm = 'CKAN'
+
+[general]
+request_classifier = repoze.who.classifiers:default_request_classifier
+challenge_decider = repoze.who.classifiers:default_challenge_decider
+
+[identifiers]
+plugins =
+    friendlyform;browser
+    use_beaker
+
+[authenticators]
+plugins =
+    ckanext.security.authenticator:CKANLoginThrottle
+    ckanext.security.authenticator:BeakerRedisAuth
+
+[challengers]
+plugins =
+    friendlyform;browser
+#   basicauth


### PR DESCRIPTION
## Cómo probar la solución

1. Levantar una instancia de Andino con la configuración SSL activada
2. Activar el plugin ejecutando el script `/etc/ckan_init.d/security/enable_ckanext_security.sh`
3. Loguearse como admin/admin (no debería tirar ningún error, siempre y cuando exista el usuario)
4. Ejecutar `/etc/ckan_init.d/paster.sh --plugin=ckan sysadmin add prueba email=john@doe.com password=passcorta` (debería tirar un ValidationError, ya que el plugin no permite esa contraseña)
5. Desactivar el plugin ejecutando el script `/etc/ckan_init.d/security/disable_ckanext_security.sh`
6. Loguearse de nuevo como admin/admin (no debería tirar ningún error)
7. Ejecutar de nuevo `/etc/ckan_init.d/paster.sh --plugin=ckan sysadmin add prueba email=john@doe.com password=passcorta` (debería crearse el admin "prueba" exitosamente)

Closes #95.