### PR TITLE
Agregamos al config file un campo para dcat que evita las traducciones de campos de datsets

### DIFF
--- a/base_portal/roles/portal/templates/ckan/production.ini.j2
+++ b/base_portal/roles/portal/templates/ckan/production.ini.j2
@@ -163,6 +163,11 @@ ckan.max_resource_size = 300
 ckan.datapusher.formats = csv xls xlsx tsv application/csv application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
 ckan.datapusher.url = http://{{ DEFAULT_SERVER_IP }}:8800
 
+## DCAT settings
+
+# Evitamos que dcat traduzca campos de datasets y recursos
+ckanext.dcat.translate_keys = false  
+
 # Resource Proxy settings
 # Preview size limit, default: 1MB
 #ckan.resource_proxy.max_file_size = 1048576


### PR DESCRIPTION
Closes #110 
Closes datosgobar/portal-andino-theme#472